### PR TITLE
Fix crash for app not having a locale.lproj folder

### DIFF
--- a/spaces/init.lua
+++ b/spaces/init.lua
@@ -75,7 +75,11 @@ local getDockExitTemplates = function()
 
     if #locale == 0 then locale = "en" end -- fallback to english
 
-    local contents = plist.read(path .. "/" .. locale .. ".lproj/Accessibility.strings")
+    local stringsPath = path .. "/" .. locale .. ".lproj/Accessibility.strings"
+    if hs.fs.displayName(stringsPath) == nil then
+        return
+    end
+    local contents = plist.read(stringsPath)
     AXExitToDesktop           = "^" .. contents.AXExitToDesktop:gsub("%%@", "(.-)") .. "$"
     AXExitToFullscreenDesktop = "^" .. contents.AXExitToFullscreenDesktop:gsub("%%@", "(.-)") .. "$"
 end


### PR DESCRIPTION
This is the case for the latest Docker Desktop app:

```shell
ls -laF /Applications/Docker.app/Contents/Resources/
total 15288
drwxr-xr-x@ 20 pbaillet  staff      640 Jul  7 19:59 ./
drwxr-xr-x@ 10 pbaillet  staff      320 Jul  7 19:59 ../
-rw-r--r--@  1 pbaillet  staff   239807 Jul  7 19:59 AppIcon.icns
-rw-r--r--@  1 pbaillet  staff  1897216 Jul  7 19:59 Assets.car
drwxr-xr-x@  5 pbaillet  staff      160 Jul  7 19:59 Base.lproj/
-rw-r--r--@  1 pbaillet  staff    19036 Jul  7 19:59 LICENSE.rtf
-rw-r--r--@  1 pbaillet  staff    15031 Jul  7 19:59 Login2FAWindow.nib
-rw-r--r--@  1 pbaillet  staff    13343 Jul  7 19:59 LoginWindow.nib
-rw-r--r--@  1 pbaillet  staff    30125 Jul  7 19:59 NPSWindow.nib
-rw-r--r--@  1 pbaillet  staff  5548279 Jul  7 19:59 OSS-LICENSES
-rw-r--r--@  1 pbaillet  staff    27585 Jul  7 19:59 WizardMessageDiagnose.nib
-rw-r--r--@  1 pbaillet  staff     8403 Jul  7 19:59 WizardMessageGeneric.nib
-rw-r--r--@  1 pbaillet  staff     2160 Jul  7 19:59 WizardWindow.nib
drwxr-xr-x@ 13 pbaillet  staff      416 Jul  7 19:59 bin/
drwxr-xr-x@  5 pbaillet  staff      160 Jul  7 19:59 cli-plugins/
drwxr-xr-x@  8 pbaillet  staff      256 Jul  7 19:59 etc/
drwxr-xr-x@  4 pbaillet  staff      128 Jul  7 19:59 lib/
-rw-r--r--@  1 pbaillet  staff     2237 Jul  7 19:59 linux-daemon-options.json
drwxr-xr-x@  7 pbaillet  staff      224 Jul  7 19:59 linuxkit/
drwxr-xr-x@  3 pbaillet  staff       96 Jul  7 19:59 snyk/
```
Also, no sign of `Accessibility.strings` in the App Bundle.